### PR TITLE
tree uses horizontal space more effectively by default and other smaller fixes

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -4,6 +4,9 @@ html {
     overflow:hidden;
 }
 
+body#manual {
+    overflow: auto;
+}
 
 #colorScale {
     width: 50%;

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -530,7 +530,7 @@ circle.node.search:hover {
 
 text.node{
     fill: black;
-    font-family: sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
 }
 
 text.node.select{
@@ -549,7 +549,7 @@ text.node.search:hover{
 }
 
 text.triangleText {
-    font-family: sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     opacity: 1;
     fill: black;
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -106,7 +106,7 @@ svg {
     position: absolute;
     width: 100%;
     overflow: scroll !important;
-    top: 50px;
+    top: 55px;
 }
 
 /*.vis-scale {*/
@@ -147,7 +147,7 @@ svg {
     border-color: #e7e7e7;
     border-width: thin;
     border-bottom: 0px;
-    top: 50px;
+    top: 55px;
 }
 
 #vis-container2 {
@@ -156,7 +156,7 @@ svg {
 }
 
 #page-content-wrapper {
-    padding: 0px;
+    padding: 0;
     height: 100%;
 }
 
@@ -460,20 +460,22 @@ input.treename::-webkit-input-placeholder{
 .tooltipElem{
     position: relative;
     display: inline-block;
-    border-bottom: 1px dotted black;
+    /* border-bottom: 1px dotted black;*/
     opacity: 0.9;
 }
 
 .tooltipElemText{
     fill: white;
-    font-size: 9pt;
+    font-size: 1em;
     /*font-weight: bold;*/
+    opacity: 1;
 }
 
 .tooltipElemInfoText{
     fill: white;
-    font-size: 9pt;
+    font-size: 1.1em;
     /*font-weight: bold;*/
+    opacity: 1;
 }
 
 
@@ -576,7 +578,7 @@ rect.node {
 .undo {
     padding: 5px;
     right: 5px;
-    top: 5px;
+    top: 0;
     position: absolute;
 }
 
@@ -607,7 +609,7 @@ rect.node {
 .exportTools {
     padding: 5px;
     right: 31px;
-    top: 5px;
+    top: 0;
     position: absolute;
 }
 
@@ -702,7 +704,7 @@ rect.node {
     position: absolute;
     padding: 5px;
     right: 57px;
-    top: 5px;
+    top: 0;
 }
 
 
@@ -759,7 +761,7 @@ treeToolsMenuContent {
 .searchBox {
     padding: 5px;
     right: 83px;
-    top: 5px;
+    top: 0;
     position: absolute;
 }
 

--- a/www/css/style_toolbar.css
+++ b/www/css/style_toolbar.css
@@ -559,7 +559,7 @@ circle.node.select{
 
 text.node{
     fill: black;
-    font-family: sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
 }
 
 text.node.select{
@@ -568,7 +568,7 @@ text.node.select{
 }
 
 text.triangleText {
-    font-family: sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     opacity: 1;
     fill: black;
 }

--- a/www/index.html
+++ b/www/index.html
@@ -131,7 +131,7 @@
     <!-- Sidebar -->
     <div id="sidebar-wrapper">
         <div id="menu-toggle">
-            <i class="fa fa-2x fa-arrow-circle-left" id="collapse-sidebar-span" style="color: #e7e7e7; padding-top: 2px; padding-left: 2px;"></i>
+            <i class="fa fa-2x fa-arrow-circle-left" id="collapse-sidebar-span" style="color: #e7e7e7; padding-top: 2px; padding-left: 2px;z-index: 99;"></i>
         </div>
         <div id="sidebar-wrapper-wrapper">
             <ul class="sidebar-nav">
@@ -582,18 +582,25 @@
         $("#wrapper").toggleClass("toggled");
 
         var div_footer = $("#footer_div");
-        var newWidth, sideBarWidth = 420;
+        var newWidth;
         var colorScaleWidth = 75;
 
         if ($("#collapse-sidebar-span").hasClass("fa fa-2x fa-arrow-circle-left")) {
+            $('#sidebar-wrapper').css("width", "");
             $("#collapse-sidebar-span").removeClass("fa fa-2x fa-arrow-circle-left");
             $("#collapse-sidebar-span").addClass("fa fa-2x fa-arrow-circle-right");
             newWidth = 30;
+            $('#sidebar-wrapper').css("overflow-y", "hidden");
             $('#sidebar-nav').hide();
         }
         else {
             $("#collapse-sidebar-span").removeClass("fa fa-2x fa-arrow-circle-right");
             $("#collapse-sidebar-span").addClass("fa fa-2x fa-arrow-circle-left");
+
+            $('#sidebar-wrapper').css("overflow-y", "auto");
+            if(isScrollBar()){
+                $('#sidebar-wrapper').css("width", "440");
+            }
             $('#sidebar-nav').show();
         }
 
@@ -938,13 +945,39 @@
         }
     });
 
+    function isScrollBar(){
+
+        console.log("ul.sidebar-nav: " + $("ul.sidebar-nav").height());
+        console.log("doc: " + ($(document).height() - 50));
+
+        // sidebarheight taller than document height - nav bar height -> scroll bar is visible
+        if($("ul.sidebar-nav").height() > ($(document).height() - 50)){
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
     function showHideSettingsPanel(mode) {
+
         if (mode == "show") {
-            $("#settingsPanel").slideDown(300);
-            settingsShown = true;
-            $("#sidebar-wrapper").css({
-                "overflow-y": "scroll"
+            $("#settingsPanel").slideDown(300, function() {
+
+                settingsShown = true;
+                $("#sidebar-wrapper").css({
+                    "overflow-y": "auto"
+                });
+
+                // hardcode the value, it's close enough
+                if(isScrollBar()) {
+                    $('#sidebar-wrapper').width(440);
+                } else {
+                    $('#sidebar-wrapper').width(420);
+                }
+
             });
+
         } else if (mode == "hide") {
             $("#settingsPanel").slideUp(300, function () {
                 settingsShown = false;
@@ -952,14 +985,20 @@
                     "display": "none"
                 });
 
-                //$("#sidebar-wrapper").css({
-                //    "overflow-y": "hidden"
-                //});
+                // hardcode the value, it's close enough
+                if(isScrollBar()) {
+                    $('#sidebar-wrapper').width(440);
+                } else {
+                    $('#sidebar-wrapper').width(420);
+                }
+
             });
         } else {
             console.log("You should not be able to see this!!!!");
         }
     }
+
+
 
     $(".sizeAdjust").change(function () {
         treecomp.changeTreeSettings({

--- a/www/index.html
+++ b/www/index.html
@@ -539,10 +539,12 @@
         });
 
         var tree1 = treecomp.addTreeGistURL(gistID[1]);
+        $("#newickInSingle").val(tree1.nwk);
         $("#page-content-wrapper").empty();
         $("#page-content-wrapper").html('<div class="container-fluid vis-container" id="vis-container1"></div><div class="vis-scale" id="vis-scale1"></div>');
+
+        var tree1 = treecomp.addTree($("#newickInSingle").val(), undefined, "single");
         treecomp.viewTree(tree1.name, "vis-container1", "vis-scale1");
-        $("#newickInSingle").val(tree1.nwk);
 
         $("#colorScale").empty();
         $("#action").css({"display": "none"});
@@ -563,9 +565,11 @@
         $("#page-content-wrapper").empty();
 
         $("#page-content-wrapper").html('<div class="container-fluid vis-container-2" id="vis-container1"></div><div class="container-fluid vis-container-2" id="vis-container2"></div>');
-        treecomp.compareTrees(tree1.name, "vis-container1", tree2.name, "vis-container2", "vis-scale1", "vis-scale2");
         $("#newickIn1").val(tree1.nwk);
         $("#newickIn2").val(tree2.nwk);
+        var tree1 = treecomp.addTree($("#newickIn1").val(), undefined, "left");
+        var tree2 = treecomp.addTree($("#newickIn2").val(), undefined, "right");
+        treecomp.compareTrees(tree1.name, "vis-container1", tree2.name, "vis-container2", "vis-scale1", "vis-scale2");
 
         $("#colorScale").empty();
         treecomp.renderColorScale("colorScale");

--- a/www/index.html
+++ b/www/index.html
@@ -14,6 +14,7 @@
     <script type="text/javascript" src="js/circular-json.js"></script>
     <script type="text/javascript" src="js/canvas-toBlob.js"></script>
     <script type="text/javascript" src="js/FileSaver.min.js"></script>
+    <!--<script type="text/javascript" src="js/nexus.js"></script>-->
     <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
@@ -803,6 +804,7 @@
                 $("#page-content-wrapper").html('<div class="container-fluid vis-container-2" id="vis-container1"></div><div class="container-fluid vis-container-2" id="vis-container2"></div>');
                 var tree1 = treecomp.addTree($("#newickIn1").val(), undefined, "left");
                 var tree2 = treecomp.addTree($("#newickIn2").val(), undefined, "right");
+
                 treecomp.changeCanvasSettings({
                     autoCollapse: tree1.data.autoCollapseDepth
                 })
@@ -819,13 +821,13 @@
                 $("#action").css({"display": "block"});
             } catch (e) {
                 if (e === "TooLittle)") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Tree file not correct: too little ")"</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Tree file not correct: too little ")"</div>')).hide().slideDown(300);
                 } else if (e === "TooLittle(") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Tree file not correct: too little "("</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Tree file not correct: too little "("</div>')).hide().slideDown(300);
                 } else if (e === "NoTree") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Please add tree</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Please add tree</div>')).hide().slideDown(300);
                 } else if (e === "") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Empty</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Empty</div>')).hide().slideDown(300);
                 }
             }
 //            if
@@ -853,13 +855,13 @@
                 $("#action").css({"display": "none"});
             } catch (e) {
                 if (e === "TooLittle)") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Tree file not correct: too little ")"</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Tree file not correct: too little ")"</div>')).hide().slideDown(300);
                 } else if (e === "TooLittle(") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Tree file not correct: too little "("</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Tree file not correct: too little "("</div>')).hide().slideDown(300);
                 } else if (e === "NoTree") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Please add tree</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Please add tree</div>')).hide().slideDown(300);
                 } else if (e === "") {
-                    $("#renderErrorMessage").append($('<div class="alert alert-danger" role="alert">Empty</div>')).hide().slideDown(300);
+                    $("#renderErrorMessage").append($('<div style="width: 100%" class="alert alert-danger" role="alert">Empty</div>')).hide().slideDown(300);
                 }
             }
         }

--- a/www/index.html
+++ b/www/index.html
@@ -14,14 +14,12 @@
     <script type="text/javascript" src="js/circular-json.js"></script>
     <script type="text/javascript" src="js/canvas-toBlob.js"></script>
     <script type="text/javascript" src="js/FileSaver.min.js"></script>
-    <script src="https://use.fontawesome.com/28dcb2432d.js"></script>
-
+    <script defer src="https://use.fontawesome.com/releases/v5.0.6/js/all.js"></script>
 
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="css/bootstrap-theme.min.css">
     <link rel="stylesheet" type="text/css" href="css/simple-sidebar.css">
     <link rel="stylesheet" type="text/css" href="css/style.css">
-    <link rel="stylesheet" type="text/css" href="css/font-awesome.css">
     <link rel="stylesheet" type="text/css" href="css/ol.css">
     <script>
         (function (i, s, o, g, r, a, m) {
@@ -131,7 +129,7 @@
     <!-- Sidebar -->
     <div id="sidebar-wrapper">
         <div id="menu-toggle">
-            <i class="fa fa-2x fa-arrow-circle-left" id="collapse-sidebar-span" style="color: #e7e7e7; padding-top: 2px; padding-left: 2px;z-index: 99;"></i>
+            <i class="fas fa-2x fa-arrow-circle-left" id="collapse-sidebar-span" style="color: #e7e7e7; padding-top: 2px; padding-left: 2px;z-index: 99;"></i>
         </div>
         <div id="sidebar-wrapper-wrapper">
             <ul class="sidebar-nav">
@@ -153,7 +151,7 @@
                                 <input class="fileIn" id="newickInSingleFile" type="file" style="display:none">
                                 <button class="btn btn-default btn-xs fileIn pull-right" id="newickInSingleButton"
                                         type="button">
-                                    Upload&nbsp;<i class="fa fa-upload" aria-hidden="true"></i>
+                                    Upload&nbsp;<i class="fas fa-upload" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
@@ -182,7 +180,7 @@
                                 <input class="fileIn" id="newickIn1File" type="file" style="display:none">
                                 <button class="btn btn-default btn-xs fileIn pull-right" id="newickIn1Button"
                                         type="button">
-                                    Upload&nbsp;<i class="fa fa-upload" aria-hidden="true"></i>
+                                    Upload&nbsp;<i class="fas fa-upload" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
@@ -199,7 +197,7 @@
                                 <input class="fileIn" id="newickIn2File" type="file" style="display:none">
                                 <button class="btn btn-default btn-xs fileIn pull-right" id="newickIn2Button"
                                         type="button">
-                                    Upload&nbsp;<i class="fa fa-upload" aria-hidden="true"></i>
+                                    Upload&nbsp;<i class="fas fa-upload" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
@@ -234,9 +232,7 @@
                     </div>
                 </li>
                 <li>
-                    <a href="#" id="settings" style="line-height: 25px; text-decoration: none;"><i style="vertical-align: middle; text-align: center; margin: 0;"
-                                                                                                   class="fa fa-pencil-square-o"
-                                                                                                   aria-hidden="true"></i>
+                    <a href="#" id="settings" style="line-height: 25px; text-decoration: none;"><i style="vertical-align: middle; text-align: center; margin: 0;" class="far fa-edit" aria-hidden="true"></i>
                         Settings&nbsp;
                     </a>
                     <div id="settingsPanel">
@@ -248,12 +244,12 @@
                                 <div id="autoCollapseButtons">
                                     <button type="button" id="collapseDec"
                                             class="btn btn-default btn-xs collapseButton">
-                                        <i style="margin-left: 2px; vertical-align: middle;" class="fa fa-minus"
+                                        <i style="margin-left: 2px; vertical-align: middle;" class="fas fa-minus"
                                            aria-hidden="true"></i>
                                     </button>
                                     <span id="collapseAmount" class="collapseElem">3</span>
                                     <button type="button" id="collapseInc" class="btn btn-default btn-xs collapseButton">
-                                        <i class="fa fa-plus" aria-hidden="true"></i>
+                                        <i class="fas fa-plus" aria-hidden="true"></i>
                                     </button>
                                 </div>
                             </div>
@@ -585,23 +581,27 @@
         var newWidth;
         var colorScaleWidth = 75;
 
-        if ($("#collapse-sidebar-span").hasClass("fa fa-2x fa-arrow-circle-left")) {
-            $('#sidebar-wrapper').css("width", "");
-            $("#collapse-sidebar-span").removeClass("fa fa-2x fa-arrow-circle-left");
-            $("#collapse-sidebar-span").addClass("fa fa-2x fa-arrow-circle-right");
-            newWidth = 30;
-            $('#sidebar-wrapper').css("overflow-y", "hidden");
-            $('#sidebar-nav').hide();
-        }
-        else {
-            $("#collapse-sidebar-span").removeClass("fa fa-2x fa-arrow-circle-right");
-            $("#collapse-sidebar-span").addClass("fa fa-2x fa-arrow-circle-left");
+        var sidebar_icon = $('#collapse-sidebar-span');
 
+        var sb_indicator = sidebar_icon.attr('data-icon');
+
+        if (sb_indicator === "arrow-circle-left") {
+            $('#sidebar-nav').hide();
+            sidebar_icon.attr('data-icon', 'arrow-circle-right');
+            newWidth = 30;
+            $('#sidebar-wrapper').css("width", "");
+            $('#sidebar-wrapper').css("overflow-y", "hidden");
+
+        } else {
+            $('#sidebar-nav').show();
+            sidebar_icon.attr('data-icon', 'arrow-circle-left');
             $('#sidebar-wrapper').css("overflow-y", "auto");
             if(isScrollBar()){
-                $('#sidebar-wrapper').css("width", "440");
+                $('#sidebar-wrapper').css("width", "437");
+            } else {
+                $('#sidebar-wrapper').css("width", "420");
             }
-            $('#sidebar-nav').show();
+
         }
 
         div_footer.width(newWidth);
@@ -947,9 +947,6 @@
 
     function isScrollBar(){
 
-        console.log("ul.sidebar-nav: " + $("ul.sidebar-nav").height());
-        console.log("doc: " + ($(document).height() - 50));
-
         // sidebarheight taller than document height - nav bar height -> scroll bar is visible
         if($("ul.sidebar-nav").height() > ($(document).height() - 50)){
             return true;
@@ -962,7 +959,7 @@
     function showHideSettingsPanel(mode) {
 
         if (mode == "show") {
-            $("#settingsPanel").slideDown(300, function() {
+            $("#settingsPanel").slideDown(200, function() {
 
                 settingsShown = true;
                 $("#sidebar-wrapper").css({
@@ -971,7 +968,7 @@
 
                 // hardcode the value, it's close enough
                 if(isScrollBar()) {
-                    $('#sidebar-wrapper').width(440);
+                    $('#sidebar-wrapper').width(437);
                 } else {
                     $('#sidebar-wrapper').width(420);
                 }
@@ -979,7 +976,7 @@
             });
 
         } else if (mode == "hide") {
-            $("#settingsPanel").slideUp(300, function () {
+            $("#settingsPanel").slideUp(100, function () {
                 settingsShown = false;
                 $(this).css({
                     "display": "none"
@@ -987,7 +984,7 @@
 
                 // hardcode the value, it's close enough
                 if(isScrollBar()) {
-                    $('#sidebar-wrapper').width(440);
+                    $('#sidebar-wrapper').width(437);
                 } else {
                     $('#sidebar-wrapper').width(420);
                 }

--- a/www/js/treecompare.js
+++ b/www/js/treecompare.js
@@ -1325,7 +1325,7 @@ var TreeCompare = function() {
 
 
     function getTreeFromCanvasId(id) {
-        var name = d3.select("#" + id + " svg").attr("id");
+        var name = $("#" + id + " > svg").attr('id');
         return trees[findTreeIndex(name)];
 
     }

--- a/www/js/treecompare.js
+++ b/www/js/treecompare.js
@@ -3828,13 +3828,12 @@ var TreeCompare = function() {
                 .text("png");
         }
 
-        //var width = 900, height = 900;
+        //var width = 300, height = 300;
         // draws download buttons
         if (settings.enableDownloadButtons) {
 
             // draw button
             buildDownloadButton(canvasId, downloadClass);
-
 
             // PNG
             d3.select("#"+canvasId).select(".png")
@@ -3848,7 +3847,8 @@ var TreeCompare = function() {
                     var height = exportElement.getBoundingClientRect().height;
                     svgString2Image(svgString, 2 * width, 2 * height, 'png', save);
                     function save(dataBlob, filesize) {
-                        saveAs(dataBlob, 'phylo.io.png'); // FileSaver.js function
+                        var filename = (name) ? name+"." : "";
+                        saveAs(dataBlob, filename+'phylo.io.png'); // FileSaver.js function
                     }
                     svg.select("#exportLogo").remove();
                 });

--- a/www/js/treecompare.js
+++ b/www/js/treecompare.js
@@ -1,6 +1,7 @@
 var TreeCompare = function() {
 
     var trees = [];
+    var longestNode = {};
 
     var backupRoot = [];
     var renderedTrees = [];
@@ -49,7 +50,7 @@ var TreeCompare = function() {
         selectMultipleSearch: false,
         fontSize: 14,
         lineThickness: 3,
-        nodeSize: 3,
+        nodeSize: 4,
         treeWidth: 500,
         treeHeight: 15,
         moveOnClick: true,
@@ -117,8 +118,8 @@ var TreeCompare = function() {
     function resize() {
         for (var i = 0; i < renderedTrees.length; i++) {
             var data = renderedTrees[i].data;
-            $("#" + data.canvasId + " svg").width($("#" + data.canvasId).width());
-            $("#" + data.canvasId + " svg").height($("#" + data.canvasId).height());
+            $("#" + data.canvasId + " > svg").width($("#" + data.canvasId).width());
+            $("#" + data.canvasId + " > svg").height($("#" + data.canvasId).height());
         }
 
     }
@@ -839,7 +840,8 @@ var TreeCompare = function() {
         if (leafCount < 50) {
             return null;
         } else {
-            return (Math.floor(Math.log(leafCount)) + 1);
+            //return (Math.floor(Math.log(leafCount)) + 1);
+            return (Math.floor(Math.log(leafCount)) > 7 ? 9 : (Math.floor(Math.log(leafCount) + 2)));
         }
 
     }
@@ -1105,9 +1107,12 @@ var TreeCompare = function() {
                 }
                 return max;
             } else {
-                var maxLength = d.length > d.triangleLength ? d.length : d.triangleLength;
-                //var maxLength = d.length;
-                return (maxLength ? Math.max(maxLength, max) : max)
+                var maxLength = (typeof d.triangleLength == 'undefined' || d.length > d.triangleLength) ? d.length : d.triangleLength;
+                if(maxLength > max) {
+                    longestNode = d;
+                    return maxLength;
+                }
+                return max;
             }
         }
 
@@ -1437,7 +1442,7 @@ var TreeCompare = function() {
             name = "Tree " + num;
         }
 
-        console.log(newTree);
+        //console.log(newTree);
         var parsedNwk = newTree.split("$$");
         try {
             var collapsedInfoTree = convertTree(parsedNwk[2]); // calls convert function from above
@@ -1528,7 +1533,7 @@ var TreeCompare = function() {
         }
 
         postorderTraverse(tree.root, function (d) {
-            console.log(d);
+            //console.log(d);
             if (d.children && d.parent) {
                 var currentNode = d;
                 sortChildrenByNumLeaves(d, tree, direction);
@@ -4117,6 +4122,7 @@ var TreeCompare = function() {
         //render the scale if we have somewhere to put it
         if (scaleId && settings.enableScale) {
             var translatewidth = 100;
+            //var translateheight = height - 100;
             var translateheight = height - 100;
 
             d3.select("#" + canvasId + " svg")
@@ -4184,10 +4190,10 @@ var TreeCompare = function() {
 
             var newHeight;
             if (leavesVisible > 0) {
-                newHeight = renderHeight / (leavesVisible + leavesHidden);
+                newHeight = renderHeight / ((leavesVisible + leavesHidden) * 0.9);
 
             } else {
-                newHeight = renderHeight / (leavesVisible + leavesHidden);
+                newHeight = renderHeight / ((leavesVisible + leavesHidden) * 0.9);
                 newHeight = (newHeight * triangleHeightDivisor);
                 newHeight = newHeight - (newHeight / triangleHeightDivisor / 2);
                 baseTree.data.prevNoLeavesVisible = true;
@@ -4202,26 +4208,20 @@ var TreeCompare = function() {
                     longest = l;
                 }
             });
-            // var maxLength = getMaxLengthVisible(baseTree.data.root);
-            var maxLength = longest;
-            var newWidth = (width / longest) * maxLength - paddingHorizontal * 2;
-            if (newWidth < 0) {
-                newWidth = (width / longest) * maxLength;
-            }
+
             // returns length from root to farthest leaf in branch lengths
-            //maxLength = getMaxLengthVisible(baseTree.data.root);
-            baseTree.data.maxLength = maxLength;
-            baseTree.data.treeWidth = newWidth;
+            maxLength = getMaxLengthVisible(baseTree.data.root);
+            baseTree.data.maxLength = getLength(longestNode);
+            baseTree.data.treeWidth = width - (2 * paddingHorizontal);
             baseTree.data.treeHeight = newHeight;
         }
-
 
         update(baseTree.root, baseTree.data, undefined, treeToggle);
 
         baseTree.data.zoomBehaviour.translate([100, 100]);
         baseTree.data.zoomBehaviour.scale(0.8);
         d3.select("#" + baseTree.data.canvasId + " svg g")
-            .attr("transform", "translate(" + [100, 100] + ") scale(0.8)");
+            .attr("transform", "translate(" + [100, 30] + ") scale(0.8)");
 
         d3.select(self.frameElement).style("height", "500px");
 
@@ -4246,7 +4246,8 @@ var TreeCompare = function() {
                     zoomBehaviourSemantic.translate(baseTree.data.prevTransform);
                 } else {
                     zoomBehaviourSemantic.translate([0, 0]);
-                }} else if (prev === scale) {
+                }
+            } else if (prev === scale) {
 
                 var translation = d3.event.translate;
                 zoomBehaviourSemantic.translate(translation);
@@ -5210,6 +5211,21 @@ var TreeCompare = function() {
             var x = coordinates[0];
             var y = coordinates[1];
 
+            var triangleY = y - triHeight;
+            triangleType = "triangle-down";
+            // menu above node by the height of the rectangle and triangle
+            menuTop = triangleY - rectHeight;
+
+            if(y < rectHeight + triHeight) {
+                triangleY = y + triHeight;
+                y += rectHeight + triHeight * 2;
+                // flip triangle, menubox below node
+                triangleType = "triangle-up";
+                menuTop = triangleY;
+
+            }
+
+
             //draw the little triangle
             var tooltipContainer = d3.select(this.parentNode.parentNode).append("g")
                 .attr("class", "tooltipElem")
@@ -5220,31 +5236,32 @@ var TreeCompare = function() {
                 .attr("height", triHeight+rectHeight)
                 .moveToFront();
 
-
-            tooltipContainer.append("path")
-                .attr("d", function() {
-                    return "M" + x + "," + y + "L" + (x-triWidth) + "," + (y-triHeight) + "L" + (x+triWidth) + "," + (y-triHeight);
-                });
+            tooltipContainer.append('path')
+            .attr("d", d3.svg.symbol().type(triangleType).size(400))
+            .attr("transform", function(d) { return "translate(" + x + "," + triangleY + ")"; })
+            .style("fill", "black")
 
             tooltipContainer.append("rect")
                 .style("fill", "black")
                 .attr("x", function(){
                     return x-(rectWidth / 2);
+
                 })
                 .attr("y", function() {
-                    return y-triHeight - rectHeight + 1;
+                    return menuTop;
                 })
+
                 .attr("width", rectWidth)
                 .attr("height", rectHeight)
-                .attr("rx", 10)
-                .attr("ry", 10);
+                .attr("rx", 6)
+                .attr("ry", 6);
 
             function add_menu_item(selector, text_f, act_f) {
                 // get coordinates of mouse click event
 
                 d3.select(selector).append("text")
                     .attr("class", "tooltipElem tooltipElemText")
-                    .attr("y", (y-rectHeight - triHeight + tpad + textDone))
+                    .attr("y", (menuTop + tpad + textDone))
                     .attr("x", (x+(-rectWidth / 2) + rpad))
                     .attr("id", text_f)
                     .text(function(d) {
@@ -5354,13 +5371,13 @@ var TreeCompare = function() {
 
             var triWidth = 10;
             var triHeight = 15;
-            var rectWidth = 150;
-            var rectHeight = 110;
+            var rectWidth = 160;
+            var rectHeight = 120;
 
             var rpad = 10;
-            var tpad = 15;
+            var tpad = 18;
             var textDone = 0;
-            var textInc = 15;
+            var textInc = 18;
 
             // ensures that operations on branches and nodes are displayed on top of links and nodes
             d3.selection.prototype.moveToFront = function() {
@@ -5373,23 +5390,33 @@ var TreeCompare = function() {
             var coordinates = d3.mouse(this.parentNode.parentNode);
             var x = coordinates[0];
             var y = coordinates[1];
+            var triangleY = y - triHeight;
+            triangleType = "triangle-down";
+            // menu above node by the height of the rectangle and triangle
+            menuTop = triangleY - rectHeight;
 
+            if(y < rectHeight + triHeight) {
+                triangleY = y + triHeight;
+                y += rectHeight + triHeight * 2;
+                // flip triangle, menubox below node
+                triangleType = "triangle-up";
+                menuTop = triangleY;
 
-
+            }
 
             //draw the little triangle
             var tooltipContainer = d3.select(this.parentNode.parentNode).append("g")
                 .attr("class", "tooltipElem")
                 .attr("top", x)
-                .attr("left",y)
+                .attr("left", y)
                 .attr("width", rectWidth)
                 .attr("height", triHeight+rectHeight)
                 .moveToFront();
 
-            tooltipContainer.append("path")
-                .attr("d", function() {
-                    return "M" + x + "," + y + "L" + (x-triWidth) + "," + (y-triHeight) + "L" + (x+triWidth) + "," + (y-triHeight);
-                });
+            tooltipContainer.append('path')
+            .attr("d", d3.svg.symbol().type(triangleType).size(400))
+            .attr("transform", function(d) { return "translate(" + x + "," + triangleY + ")"; })
+            .style("fill", "black")
 
             tooltipContainer.append("rect")
                 .style("fill", "black")
@@ -5398,21 +5425,19 @@ var TreeCompare = function() {
 
                 })
                 .attr("y", function() {
-                    return y-triHeight - rectHeight + 1;
+                    return menuTop;
                 })
+
                 .attr("width", rectWidth)
                 .attr("height", rectHeight)
-                .attr("rx", 10)
-                .attr("ry", 10);
-
-
-            // textDone += textInc;
+                .attr("rx", 6)
+                .attr("ry", 6);
 
 
             function add_menu_item(selector, text_f, act_f) {
                 d3.select(selector).append("text")
                     .attr("class", "tooltipElem tooltipElemText")
-                    .attr("y", (y-rectHeight - triHeight + tpad + textDone))
+                    .attr("y", (menuTop + tpad + textDone))
                     .attr("x", (x+(-rectWidth / 2) + rpad))
                     .attr("id", text_f)
                     .text(function(d) {
@@ -5426,17 +5451,18 @@ var TreeCompare = function() {
             };
 
             if (d.children || d._children) {
+
                 tooltipContainer.append("line")
                     .attr("x1", (x+(-rectWidth / 2)))
                     .attr("x2", (x+(-rectWidth / 2))+rectWidth)
-                    .attr("y1", (y-rectHeight - triHeight + tpad + textDone)+3)
-                    .attr("y2", (y-rectHeight - triHeight + tpad + textDone)+3)
-                    .attr("stroke", "grey")
-                    .attr("stroke-width", "1.5");
+                    .attr("y1", (menuTop + tpad + textDone)+6)
+                    .attr("y2", (menuTop + tpad + textDone)+6)
+                    .attr("stroke", "white")
+                    .attr("stroke-width", "1");
 
                 d3.select(".tooltipElem").append("text")
                     .attr("class", "tooltipElemInfoText")
-                    .attr("y", (y-rectHeight - triHeight + tpad + textDone))
+                    .attr("y", (menuTop + tpad + textDone))
                     .attr("x", (x+(-rectWidth / 2) + rpad))
                     .attr("id", "infoText")
                     .text(function() {
@@ -5446,8 +5472,10 @@ var TreeCompare = function() {
                             return '#leaf: '+d.leaves.length;
                         }
                     });
-                textDone += textInc;
+                // small extra space after infotext line
+                textDone += textInc + 4;
             }
+
             if (!d.children && !d._children) {
                 add_menu_item(".tooltipElem",
                     function () { // text function

--- a/www/manual.html
+++ b/www/manual.html
@@ -26,7 +26,7 @@ body {
 }
 </style>
 
-<body>
+<body id="manual">
     <nav class="navbar navbar-default navbar-fixed-top">
         <div class="">
             <div class="navbar-header">


### PR DESCRIPTION
- make tree div/svg use more of the available space
- tweak vis-container placement and margins
- tooltip style tweaks, bigger font size, more padding
- default rescale uses horizontal space better, by calculating longest visible node length instead of longest node length
- window resize don't zoom other svg elements but the tree
- recommended autocollapse tweaked a little