### PR TITLE
fix: categorical color scale maps all categories to distinct colors

### DIFF
--- a/src/color_mapper.js
+++ b/src/color_mapper.js
@@ -7,13 +7,12 @@ export default class Color_mapper {
 
         this.cpt = 1
 
-        this.scheme = d3.scaleSequential(d3.interpolateRainbow)
-        this.scheme_name = 'Viridis'
-
-        this.scale = this.scheme
-            .domain([0, this.cpt/2, this.cpt])
+        this.scheme = d3.interpolateRainbow
+        this.scheme_name = 'Rainbow'
 
         this.domain_mapping = {}
+
+        this.scale = d3.scaleSequential(this.scheme).domain([0, this.cpt])
 
     }
 
@@ -34,7 +33,7 @@ export default class Color_mapper {
     }
 
     update(){
-        this.scale = d3.scaleSequential(this.scheme).domain([0, this.cpt/2, this.cpt])
+        this.scale = d3.scaleSequential(this.scheme).domain([0, this.cpt])
 
     }
 


### PR DESCRIPTION
Fix for the issue with different categories using the same color coming from the d3 domain function taking only an array of 2 values (min, max) so ignoring the third parameter with total number and producing a range to half the size of cpt.
Also renamed the default scheme name to 'Rainbow' to correspond with the above d3.interpolateRainbow, or use d3.interpolateViridis if you prefer the default to be 'Viridis'.